### PR TITLE
Addition of pip install feature for miniradiotools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ __pycache__
 .DS_Store
 
 *.pyc
+
+# pypi stuff
+dist
+*.egg-info

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2024 Jelena Köhler
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plot_traces.py
+++ b/plot_traces.py
@@ -5,7 +5,7 @@ import matplotlib as mpl
 from matplotlib import rc
 import glob
 from optparse import OptionParser
-import sys
+import os, sys
 
 # mpl setup
 mpl.rcParams['lines.markersize'] = 5
@@ -25,6 +25,10 @@ parser.add_option("--out", "-o", type="str", dest="out",
 
 
 (options, args) = parser.parse_args()
+
+# make sure options.file exists
+if not options.file:
+    raise Exception("Please specify a file.")
 
 # * * * * * * * * * * * * * * * * *
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "miniradiotools"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Keito Watanabe"},
   { name="Jelena Köhler"},
   { name="Lukas Gülzow"},
 ]
-description = "Unleash the magic of simultaneous shower simulations with this Coreas generator."
+description = "A minature analysis tool for radio emission of air showers."
 readme = "README.md"
 license = {file = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "miniradiotools"
+version = "0.1.1"
+authors = [
+  { name="Keito Watanabe"},
+  { name="Jelena Köhler"},
+  { name="Lukas Gülzow"},
+]
+description = "Unleash the magic of simultaneous shower simulations with this Coreas generator."
+readme = "README.md"
+license = {file = "LICENSE"}
+dependencies = [
+  "numpy",
+  "matplotlib",
+  'radiotools'
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+
+[project.urls]
+Homepage = "https://github.com/jelenakhlr/miniradiotools"
+Issues = "https://github.com/jelenakhlr/miniradiotools/issues"


### PR DESCRIPTION
I have added a feature to `pip` install the miniradiotools. By running `pip install miniradiotools`, it installs numpy, Matplotlib, and radiotools as the dependencies as well. Currently its only up in testPyPI, but I can push it to PyPI itself once this merge is approved.

I also added a LICENSE file to the code (BSD-3).

I also made some minor improvements to the existing codes to make sure that a file is specified for `plot_traces.py`

